### PR TITLE
Don't use rpath

### DIFF
--- a/libdigidoc/CMakeLists.txt
+++ b/libdigidoc/CMakeLists.txt
@@ -95,7 +95,6 @@ set_target_properties( digidoc PROPERTIES
 
 if( BUILD_TOOLS )
 	add_executable(cdigidoc cdigidoc.c cdigidoc.rc)
-	set_target_properties(cdigidoc PROPERTIES INSTALL_RPATH "@loader_path/../../../..;@loader_path/../..")
 	target_link_libraries(cdigidoc digidoc)
 endif()
 


### PR DESCRIPTION
As described in [this Debian Wiki article](https://wiki.debian.org/RpathIssue) and elsewhere, using RPATH is generally not a very good idea.
