### PR TITLE
Add some missing prototypes and includes

### DIFF
--- a/libdigidoc/DigiDocCert.h
+++ b/libdigidoc/DigiDocCert.h
@@ -310,6 +310,10 @@ EXP_OPTION int verifyCertificateByOCSPWithIp(X509* pCert, const X509** caCerts,
   //--------------------------------------------------
   EXP_OPTION int readSubjectKeyIdentifier(X509* pCert, DigiDocMemBuf* pMemBuf);
 
+  EXP_OPTION int ddocCertGetDNPart(X509* pCert, DigiDocMemBuf* pMemBuf, int nNid, int bIssuer);
+
+  EXP_OPTION int ddocCertGetDN(X509* pCert, DigiDocMemBuf* pMemBuf, int bIssuer);
+
 //================< deprecated functions> =================================
 // these functions are deprecated. Use the replacements in DigiDocCert.h
 // these functions will be removed in future releases!

--- a/libdigidoc/DigiDocOCSP.c
+++ b/libdigidoc/DigiDocOCSP.c
@@ -42,6 +42,7 @@
 #include <openssl/pkcs12.h>
 #include <openssl/rand.h>
 #include <ctype.h>
+#include <string.h>
 
 #ifdef FRAMEWORK
 #ifdef __APPLE__

--- a/libdigidoc/DigiDocSAXParser.c
+++ b/libdigidoc/DigiDocSAXParser.c
@@ -32,6 +32,7 @@
 #include <libdigidoc/DigiDocOCSP.h>
 #include <libdigidoc/DigiDocDfExtract.h>
 #include <libdigidoc/DigiDocVerify.h>
+#include <libdigidoc/DigiDocGen.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <memory.h>

--- a/libdigidoc/DigiDocSAXParser.h
+++ b/libdigidoc/DigiDocSAXParser.h
@@ -94,6 +94,7 @@ EXP_OPTION int ddocReadNewSignaturesFromDdoc(SignedDoc* pSigDoc, const char* szF
 //AM 13.03.2008
 void decodeURI(const char* uri, char* id, int nIdLen, char* adr, int nAdrLen);
 
+EXP_OPTION int ddocAddSignatureFromMemory(SignedDoc* pSigDoc, const char* szFileName, const void* pSigBuf, int nSigLen);
 
     
 #ifdef  __cplusplus

--- a/libdigidoc/DigiDocVerify.c
+++ b/libdigidoc/DigiDocVerify.c
@@ -47,6 +47,8 @@
 #include <openssl/pkcs12.h>
 #include <openssl/rand.h>
 
+#include <string.h>
+
 #if OPENSSL_VERSION_NUMBER < 0x10010000L
 static EVP_MD_CTX *EVP_MD_CTX_new()
 {

--- a/libdigidoc/DigiDocVerify.h
+++ b/libdigidoc/DigiDocVerify.h
@@ -168,6 +168,7 @@ EXP_OPTION int verifyEstIDSignature2(const byte* digest, int digestLen, int nDig
 //============================================================
 EXP_OPTION int checkDdocWrongDigests(const SignedDoc* pSigDoc);
     
+EXP_OPTION int validateElementPath(XmlElemInfo* pElem);
 
 #ifdef  __cplusplus
 }

--- a/libdigidoc/cdigidoc.c
+++ b/libdigidoc/cdigidoc.c
@@ -69,6 +69,7 @@ char* g_szProgNameVer = "cdigidoc/"DIGIDOC_VERSION;
 //==========< forward defs >========================
 
 void printErrorsAndWarnings(SignedDoc* pSigDoc);
+int isWarning(SignedDoc* pSigDoc, int nErrCd);
 
 //==========< helper functions for argument handling >====================
 


### PR DESCRIPTION
Gets rid of some warnings regarding missing includes/function prototypes when building.