### PR TITLE
Add required include and define

### DIFF
--- a/libdigidoc/DigiDocService.c
+++ b/libdigidoc/DigiDocService.c
@@ -26,6 +26,7 @@
 #include <libdigidoc/DigiDocObj.h>
 #include <libdigidoc/DigiDocConvert.h>
 #include <libdigidoc/DigiDocGen.h>
+#include <libdigidoc/DigiDocSAXParser.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <memory.h>

--- a/libdigidoc/DigiDocVerify.c
+++ b/libdigidoc/DigiDocVerify.c
@@ -20,6 +20,7 @@
 //                      Creation
 //==================================================
 
+#define WITH_DEPRECATED_FUNCTIONS
 #include "DigiDocVerify.h"
 #include "DigiDocError.h"
 #include "DigiDocLib.h"


### PR DESCRIPTION
`DigiDocSAXParser.h` is needed in `DigiDocService.c` for the function `ddocAddSignatureFromMemory`.

`DigiDocVerify.c` uses `ddocGetDNPartFromString`, which is only prototyped in `DigiDocCert.h` if `WITH_DEPRECATED_FUNCTIONS` is defined.